### PR TITLE
use BrowserWindow instead of window.open to open links

### DIFF
--- a/webview.js
+++ b/webview.js
@@ -1,5 +1,7 @@
 import path from 'path';
-import { shell } from 'electron';
+import { shell, remote } from 'electron';
+
+const { BrowserWindow } = remote;
 
 module.exports = (Franz) => {
   const getMessages = function getMessages() {
@@ -19,7 +21,17 @@ module.exports = (Franz) => {
       e.stopImmediatePropagation();
       e.preventDefault();
 
-      window.open(elem.getAttribute('href'));
+      let win = new BrowserWindow({
+        width: 800,
+        height: window.innerHeight,
+        minWidth: 600,
+      });
+
+      win.loadURL(elem.getAttribute('href'));
+
+      win.on('closed', () => {
+        win = null
+      })
     }
   }, true);
 };


### PR DESCRIPTION
Cookies of the current session can be reused, which is required for viewing images.